### PR TITLE
Class name corrected in README.md omnistap.ogTAPTask>omnistap.kgTAPTask

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ git clone https://github.com/suransys/omnistap.git
 ## Quickstart
 ### Add OmnisTAP to your library
 1. Open `omnistap/lib/[your Omnis version]/omnistap.lbs` in Omnis Studio
-1. Set your library's startup task to subclass `omnistap.ogTAPTask`
+1. Set your library's startup task to subclass `omnistap.kgTAPTask`
 1. Restart your library's startup task
 
 ### Add a test


### PR DESCRIPTION
Just a small change in the documentation. I had to look three times through the class list before I eventually checked the Startup_Task in the example library to see that supposed to be kgTAPTask. 😉