### PR TITLE
Fix for non functioning $is_row

### DIFF
--- a/src/omnistap/OmnisTAP/ogTAPMethods/$is_list.omh
+++ b/src/omnistap/OmnisTAP/ogTAPMethods/$is_list.omh
@@ -58,10 +58,10 @@ For pfrList1.$line from 1 to pfrList1.$linecount step 1
 		End If
 	End If
 	
-	Do lrList1Row.$assignrow(pfrList1.0,kFalse)
+	Do lrList1Row.$assignrow(pfrList1,kFalse)
 	Calculate lbnList1Row as lrList1Row
 	
-	Do lrList2Row.$assignrow(pfrList2.0,kFalse)
+	Do lrList2Row.$assignrow(pfrList2,kFalse)
 	Calculate lbnList2Row as lrList2Row
 	
 	Calculate lbRowsEqual as bincompare(lbnList1Row,lbnList2Row)

--- a/src/omnistap/OmnisTAP/ogTAPMethods/class.json
+++ b/src/omnistap/OmnisTAP/ogTAPMethods/class.json
@@ -1,7 +1,7 @@
 {
 	"classtype": "kObjectclass",
 	"omnisversion": "10.2",
-	"internalversion": 64,
+	"internalversion": 65,
 	"designtaskname": "Startup_Task",
 	"cvardefs": [
 
@@ -26,7 +26,7 @@
 		"editordata": "",
 		"external": true,
 		"issupercomponent": false,
-		"moddate": "2023-03-13 15:07:59",
+		"moddate": "2023-07-13 10:17:59",
 		"selfcontained": false,
 		"showascheckedout": false,
 		"userinfo": "",

--- a/src/omnistap/library.json
+++ b/src/omnistap/library.json
@@ -1,5 +1,5 @@
 {
-	"omnisversion": "10.22",
+	"omnisversion": "10.2",
 	"includes": [
 		"OMNISCLI",
 		"OMNISTAP"


### PR DESCRIPTION
When passing row variables to $is_row, the call is passed on to $is_list. There is a loop which copies every row to a row variable to compare, but that copy fails because variable.0 is used which refers to the current row in a list, but is invalid for a row variable.